### PR TITLE
Only ingest new transactions if they are different

### DIFF
--- a/pkg/coinbase/staking_operation_test.go
+++ b/pkg/coinbase/staking_operation_test.go
@@ -26,11 +26,13 @@ func TestStakingOperation_Wait_Success(t *testing.T) {
 	}
 
 	so, err := mockStakingOperation(t, "pending")
+	so.Transactions()[0].model.Status = "complete"
 	assert.NoError(t, err, "staking operation creation should not error")
 	so, err = c.Wait(context.Background(), so)
 	assert.NoError(t, err, "staking operation wait should not error")
 	assert.Equal(t, "complete", so.Status(), "staking operation status should be complete")
 	assert.Equal(t, 1, len(so.Transactions()), "staking operation should have 1 transaction")
+	assert.Equal(t, "complete", so.Transactions()[0].Status(), "staking operation should have 1 transaction")
 }
 
 func TestStakingOperation_Wait_Success_CustomOptions(t *testing.T) {

--- a/pkg/coinbase/staking_operation_test.go
+++ b/pkg/coinbase/staking_operation_test.go
@@ -28,13 +28,13 @@ func TestStakingOperation_Wait_Success(t *testing.T) {
 	}
 
 	so, err := mockStakingOperation(t, "pending")
+	require.NoError(t, err, "failed to create staking operation")
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err, "failed to generate ecdsa key")
 	err = so.Sign(key)
+	require.NoError(t, err, "failed to sign staking operation")
 	signedPayload := so.Transactions()[0].SignedPayload()
 	require.NotEmpty(t, signedPayload, "signed payload should not be empty")
-	require.NoError(t, err, "failed to sign staking operation")
-	assert.NoError(t, err, "staking operation creation should not error")
 	so, err = c.Wait(context.Background(), so)
 	assert.NoError(t, err, "staking operation wait should not error")
 	assert.Equal(t, "complete", so.Status(), "staking operation status should be complete")

--- a/pkg/coinbase/staking_operation_test.go
+++ b/pkg/coinbase/staking_operation_test.go
@@ -30,7 +30,7 @@ func TestStakingOperation_Wait_Success(t *testing.T) {
 	so, err = c.Wait(context.Background(), so)
 	assert.NoError(t, err, "staking operation wait should not error")
 	assert.Equal(t, "complete", so.Status(), "staking operation status should be complete")
-	assert.Equal(t, len(so.Transactions()), 1, "staking operation should have 1 transaction")
+	assert.Equal(t, 1, len(so.Transactions()), "staking operation should have 1 transaction")
 }
 
 func TestStakingOperation_Wait_Success_CustomOptions(t *testing.T) {
@@ -56,7 +56,7 @@ func TestStakingOperation_Wait_Success_CustomOptions(t *testing.T) {
 	)
 	assert.NoError(t, err, "staking operation wait should not error")
 	assert.Equal(t, "complete", so.Status(), "staking operation status should be complete")
-	assert.Equal(t, len(so.Transactions()), 1, "staking operation should have 1 transaction")
+	assert.Equal(t, 1, len(so.Transactions()), "staking operation should have 1 transaction")
 }
 
 func TestStakingOperation_Wait_Failure(t *testing.T) {


### PR DESCRIPTION
### What changed? Why?
This updates the staking operation reload object to reload the model & only reload transactions in which the unsigned payload is different.

#### Qualified Impact
This impacts the staking operation model & how it reloads from the API.
