### PR TITLE
Add user facing validator statuses

### DIFF
--- a/pkg/coinbase/staking_operation.go
+++ b/pkg/coinbase/staking_operation.go
@@ -23,7 +23,7 @@ func WithStakingOperationMode(mode string) StakingOperationOption {
 
 // WithStakingOperationOption allows for the passing of custom options
 // to the staking operation, like `mode` or `withdrawal_address`.
-func WithStakingOperationOption(optionKey string, optionValue string) StakingOperationOption {
+func WithStakingOperationOption(optionKey, optionValue string) StakingOperationOption {
 	return func(op *client.BuildStakingOperationRequest) {
 		op.Options[optionKey] = optionValue
 	}

--- a/pkg/coinbase/validator.go
+++ b/pkg/coinbase/validator.go
@@ -7,6 +7,62 @@ import (
 	"github.com/coinbase/coinbase-sdk-go/gen/client"
 )
 
+type ValidatorStatus string
+
+const (
+	ValidatorStatusUnknown             ValidatorStatus = "unknown"
+	ValidatorStatusProvisioning        ValidatorStatus = "provisioning"
+	ValidatorStatusProvisioned         ValidatorStatus = "provisioned"
+	ValidatorStatusDeposited           ValidatorStatus = "deposited"
+	ValidatorStatusPendingActivation   ValidatorStatus = "pending_activation"
+	ValidatorStatusActive              ValidatorStatus = "active"
+	ValidatorStatusExiting             ValidatorStatus = "exiting"
+	ValidatorStatusExited              ValidatorStatus = "exited"
+	ValidatorStatusWithdrawalAvailable ValidatorStatus = "withdrawal_available"
+	ValidatorStatusWithdrawalComplete  ValidatorStatus = "withdrawal_complete"
+	ValidatorStatusActiveSlashed       ValidatorStatus = "active_slashed"
+	ValidatorStatusExitedSlashed       ValidatorStatus = "exited_slashed"
+	ValidatorStatusReaped              ValidatorStatus = "reaped"
+)
+
+// getAPIValidatorStatus maps the user facing ValidatorStatus to api facing ValidatorStatus
+func getAPIValidatorStatus(status *ValidatorStatus) client.ValidatorStatus {
+	if status == nil {
+		return client.VALIDATORSTATUS_UNKNOWN
+	}
+
+	switch *status {
+	case ValidatorStatusUnknown:
+		return client.VALIDATORSTATUS_UNKNOWN
+	case ValidatorStatusProvisioning:
+		return client.VALIDATORSTATUS_PROVISIONING
+	case ValidatorStatusProvisioned:
+		return client.VALIDATORSTATUS_PROVISIONED
+	case ValidatorStatusDeposited:
+		return client.VALIDATORSTATUS_DEPOSITED
+	case ValidatorStatusPendingActivation:
+		return client.VALIDATORSTATUS_PENDING_ACTIVATION
+	case ValidatorStatusActive:
+		return client.VALIDATORSTATUS_ACTIVE
+	case ValidatorStatusExiting:
+		return client.VALIDATORSTATUS_EXITING
+	case ValidatorStatusExited:
+		return client.VALIDATORSTATUS_EXITED
+	case ValidatorStatusWithdrawalAvailable:
+		return client.VALIDATORSTATUS_WITHDRAWAL_AVAILABLE
+	case ValidatorStatusWithdrawalComplete:
+		return client.VALIDATORSTATUS_WITHDRAWAL_COMPLETE
+	case ValidatorStatusActiveSlashed:
+		return client.VALIDATORSTATUS_ACTIVE_SLASHED
+	case ValidatorStatusExitedSlashed:
+		return client.VALIDATORSTATUS_EXITED_SLASHED
+	case ValidatorStatusReaped:
+		return client.VALIDATORSTATUS_REAPED
+	default:
+		return client.VALIDATORSTATUS_UNKNOWN
+	}
+}
+
 type Validator struct {
 	model client.Validator
 }
@@ -33,12 +89,11 @@ func (v Validator) ToString() string {
 	)
 }
 
-func (c *Client) ListValidators(ctx context.Context, networkId string, assetId string) ([]Validator, error) {
-	validatorList, _, err := c.client.ValidatorsAPI.ListValidators(
-		ctx,
-		normalizeNetwork(networkId),
-		assetId,
-	).Execute()
+func (c *Client) ListValidators(ctx context.Context, networkId string, assetId string, status *ValidatorStatus) ([]Validator, error) {
+	listValidatorReq := c.client.ValidatorsAPI.ListValidators(ctx, normalizeNetwork(networkId), assetId)
+	listValidatorReq = listValidatorReq.Status(getAPIValidatorStatus(status))
+
+	validatorList, _, err := listValidatorReq.Execute()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/coinbase/validators_test.go
+++ b/pkg/coinbase/validators_test.go
@@ -49,7 +49,7 @@ func (s *ValidatorSuite) TestListValidators_Success() {
 
 	s.mockSuccessfulListValidators(ctx, networkId, assetId, mockValidators)
 
-	validators, err := s.client.ListValidators(ctx, networkId, assetId)
+	validators, err := s.client.ListValidators(ctx, networkId, assetId, nil)
 
 	s.Assert().NoError(err)
 	s.Len(validators, 1)
@@ -65,7 +65,7 @@ func (s *ValidatorSuite) TestListValidators_Failure() {
 
 	s.mockFailedListValidators(ctx, networkId, assetId, fmt.Errorf(errorMessage))
 
-	validators, err := s.client.ListValidators(ctx, networkId, assetId)
+	validators, err := s.client.ListValidators(ctx, networkId, assetId, nil)
 
 	s.Assert().Nil(validators)
 	s.EqualError(err, errorMessage)

--- a/pkg/coinbase/validators_test.go
+++ b/pkg/coinbase/validators_test.go
@@ -49,6 +49,31 @@ func (s *ValidatorSuite) TestListValidators_Success() {
 
 	s.mockSuccessfulListValidators(ctx, networkId, assetId, mockValidators)
 
+	validators, err := s.client.ListValidators(ctx, networkId, assetId)
+
+	s.Assert().NoError(err)
+	s.Len(validators, 1)
+	s.Equal("validator-1", validators[0].ID())
+	s.Equal(api.VALIDATORSTATUS_ACTIVE, validators[0].Status())
+}
+
+// Since options are a slice a user can pass a nil which we should try and handle.
+func (s *ValidatorSuite) TestListValidators_Success_WithNilOptions() {
+	ctx := context.Background()
+	networkId := "test-network"
+	assetId := "test-asset"
+
+	mockValidators := &api.ValidatorList{
+		Data: []api.Validator{
+			{
+				ValidatorId: "validator-1",
+				Status:      api.VALIDATORSTATUS_ACTIVE,
+			},
+		},
+	}
+
+	s.mockSuccessfulListValidators(ctx, networkId, assetId, mockValidators)
+
 	validators, err := s.client.ListValidators(ctx, networkId, assetId, nil)
 
 	s.Assert().NoError(err)
@@ -65,7 +90,7 @@ func (s *ValidatorSuite) TestListValidators_Failure() {
 
 	s.mockFailedListValidators(ctx, networkId, assetId, fmt.Errorf(errorMessage))
 
-	validators, err := s.client.ListValidators(ctx, networkId, assetId, nil)
+	validators, err := s.client.ListValidators(ctx, networkId, assetId)
 
 	s.Assert().Nil(validators)
 	s.EqualError(err, errorMessage)


### PR DESCRIPTION
### What changed? Why?

This PR help add user facing validator status's that can be used to filter validators.


### Testing

Tested using this code

```
package main

import (
	"context"
	"fmt"
	"log"

	"github.com/coinbase/coinbase-sdk-go/pkg/coinbase"
)

func main() {
	ctx := context.Background()
	client, err := coinbase.NewClient(
		coinbase.WithAPIKeyFromJSON("api-key.json"),
	)
	if err != nil {
		log.Fatalf("error creating coinbase client: %v", err)
	}

	// List all validators.
	log.Println("Listing all validators")
	validators, err := client.ListValidators(ctx, "ethereum-holesky", coinbase.Eth)
	if err != nil {
		log.Fatalf("error listing rewards: %v", err)
	}

	for _, validator := range validators {
		fmt.Println(validator.ToString())
	}

	// List all active validators.
	log.Println("Listing all active validators")
	validators, err = client.ListValidators(
		ctx,
		"ethereum-holesky",
		coinbase.Eth,
		coinbase.WithListValidatorsStatusOption(coinbase.ValidatorStatusActive),
	)
	if err != nil {
		log.Fatalf("error listing rewards: %v", err)
	}

	for _, validator := range validators {
		fmt.Println(validator.ToString())
	}

	// Get a specific validator.
	log.Println("Getting a specific validator")
	validator, err := client.GetValidator(ctx, "ethereum-holesky", coinbase.Eth, "0x940303549cf1ccf6e9aafbc7996974b4f48ff112a3ca41ba187d9725dfc4f4c715105ec711221448dc50c777e0108066")
	if err != nil {
		log.Fatalf("error getting validator: %v", err)
	}

	fmt.Printf("Validator id [%s] has state: %s", validator.ID(), validator.Status())
}

```


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
