### PR TITLE
Allow for use with directly set api key

### DIFF
--- a/pkg/coinbase/client.go
+++ b/pkg/coinbase/client.go
@@ -42,6 +42,17 @@ func WithAPIKeyFromJSON(fileName string) ClientOption {
 	}
 }
 
+// WithAPIKey sets the explicit API key for the client loaded
+func WithAPIKey(name, privateKey string) ClientOption {
+	return func(c *Client) error {
+		c.apiKey = auth.APIKey{
+			Name:       name,
+			PrivateKey: privateKey,
+		}
+		return nil
+	}
+}
+
 // WithHTTPClient sets the http client for the client
 func WithHTTPClient(httpClient *http.Client) ClientOption {
 	return func(c *Client) error {

--- a/pkg/coinbase/client_test.go
+++ b/pkg/coinbase/client_test.go
@@ -60,6 +60,33 @@ func TestWithAPIKeyFromJSON(t *testing.T) {
 	}
 }
 
+func TestWithAPIKey(t *testing.T) {
+	tests := []struct {
+		name         string
+		keyName      string
+		privateKey   string
+		expectations func(t *testing.T, c *Client, err error)
+	}{
+		{
+			name:       "should eq test_key and some-name",
+			keyName:    "some-name",
+			privateKey: "test_key",
+			expectations: func(t *testing.T, c *Client, err error) {
+				assert.Equal(t, "test_key", c.apiKey.PrivateKey)
+				assert.Equal(t, "some-name", c.apiKey.Name)
+				assert.NoError(t, err)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{cfg: client.NewConfiguration()}
+			err := WithAPIKey(tt.keyName, tt.privateKey)(c)
+			tt.expectations(t, c, err)
+		})
+	}
+}
+
 func TestWithHTTPClient(t *testing.T) {
 	testClient := &http.Client{}
 	tests := []struct {


### PR DESCRIPTION
### What changed? Why?
Allows a developer to explicitly set an API key if they want to use ENV vars, or other configuration means.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
