### PR TITLE
[chore] Adds an SDK language and version to the heads passed to cdp-service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## [0.0.7] - 2024-09-12
+
+- Adds headers to requests with SDK version & language
+
 ## [0.0.6] - 2024-09-12
 
 ### Added
@@ -39,9 +43,9 @@
 
 Initial release of the Coinbase Go SDK
 
-- Support for Staking on External Wallets 
+- Support for Staking on External Wallets
     - Full support for Shared ETH Staking
-    - Partial support for Dedicated ETH Staking 
+    - Partial support for Dedicated ETH Staking
       - Only stake is supported, unstake will be coming soon
     - On networks `holesky` and `mainnet`
 - Support for getting stakeable balances on External Wallets

--- a/pkg/auth/transport.go
+++ b/pkg/auth/transport.go
@@ -31,6 +31,12 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", jwt))
+	fmt.Sprintf(
+		"%s,%s",
+		fmt.Sprintf("%s=%s", "sdk_version", "0.0.6"),
+		fmt.Sprintf("%s=%s", "sdk_language", "go"),
+	)
+	req.Header.Set("Correlation-Context", fmt.Sprintf("Bearer %s", jwt))
 
 	return t.transport.RoundTrip(req)
 }

--- a/pkg/auth/transport.go
+++ b/pkg/auth/transport.go
@@ -33,10 +33,10 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", jwt))
 
 	req.Header.Set(
-		"Correlation-Context", 
+		"Correlation-Context",
 		fmt.Sprintf(
 			"%s,%s",
-			fmt.Sprintf("%s=%s", "sdk_version", "0.0.6"),
+			fmt.Sprintf("%s=%s", "sdk_version", "0.0.7"),
 			fmt.Sprintf("%s=%s", "sdk_language", "go"),
 		),
 	)

--- a/pkg/auth/transport.go
+++ b/pkg/auth/transport.go
@@ -31,12 +31,15 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", jwt))
-	fmt.Sprintf(
-		"%s,%s",
-		fmt.Sprintf("%s=%s", "sdk_version", "0.0.6"),
-		fmt.Sprintf("%s=%s", "sdk_language", "go"),
+
+	req.Header.Set(
+		"Correlation-Context", 
+		fmt.Sprintf(
+			"%s,%s",
+			fmt.Sprintf("%s=%s", "sdk_version", "0.0.6"),
+			fmt.Sprintf("%s=%s", "sdk_language", "go"),
+		),
 	)
-	req.Header.Set("Correlation-Context", fmt.Sprintf("Bearer %s", jwt))
 
 	return t.transport.RoundTrip(req)
 }


### PR DESCRIPTION
### What changed? Why?

This will help telemetry so we can support customers & identify bad versions better.

#### Qualified Impact

During the auth header addition we will also append sdk version & language information
