### PR TITLE
Update rewards apis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## [0.0.8] - 2024-09-17
+
+- StakingRewards's Date field is now a full timestamp
+- StakingBalance's Date field is now a full timestamp
+- Empty balance values default to 0
+
 ## [0.0.7] - 2024-09-12
 
 - Adds headers to requests with SDK version & language

--- a/pkg/auth/transport.go
+++ b/pkg/auth/transport.go
@@ -36,7 +36,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		"Correlation-Context",
 		fmt.Sprintf(
 			"%s,%s",
-			fmt.Sprintf("%s=%s", "sdk_version", "0.0.7"),
+			fmt.Sprintf("%s=%s", "sdk_version", "0.0.8"),
 			fmt.Sprintf("%s=%s", "sdk_language", "go"),
 		),
 	)

--- a/pkg/coinbase/balance.go
+++ b/pkg/coinbase/balance.go
@@ -38,9 +38,15 @@ func newBalanceFromModel(model *client.Balance) (*Balance, error) {
 	if err != nil {
 		return nil, err
 	}
-	amount, ok := new(big.Int).SetString(model.Amount, 10)
-	if !ok {
-		return nil, fmt.Errorf("failed to parse amount: %s", model.Amount)
+
+	amount := big.NewInt(0)
+
+	if model.GetAmount() != "" {
+		a, ok := new(big.Int).SetString(model.Amount, 10)
+		if !ok {
+			return nil, fmt.Errorf("failed to parse amount: %s", model.Amount)
+		}
+		amount = a
 	}
 
 	return &Balance{

--- a/pkg/coinbase/balance_test.go
+++ b/pkg/coinbase/balance_test.go
@@ -48,6 +48,27 @@ func TestBalance_String(t *testing.T) {
 			}(),
 			want: "Balance { amount: '100' asset: 'Asset { networkId: 'networkId' assetId: 'assetId' contractAddress: 'contractAddress' decimals: '18' }' }",
 		},
+		{
+			name: "empty amount",
+			b: func() *Balance {
+				dec := int32(18)
+				contractAddress := "contractAddress"
+				balance, err := newBalanceFromModel(&client.Balance{
+					Asset: client.Asset{
+						NetworkId:       "networkId",
+						AssetId:         "assetId",
+						ContractAddress: &contractAddress,
+						Decimals:        &dec,
+					},
+					Amount: "",
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return balance
+			}(),
+			want: "Balance { amount: '0' asset: 'Asset { networkId: 'networkId' assetId: 'assetId' contractAddress: 'contractAddress' decimals: '18' }' }",
+		},
 	}
 	for _, tt := range tests {
 		assert.Equal(t, tt.want, tt.b.String())

--- a/pkg/coinbase/staking_balance.go
+++ b/pkg/coinbase/staking_balance.go
@@ -78,7 +78,7 @@ func (c *Client) ListHistoricalStakingBalances(
 }
 
 func newStakingBalanceFromModel(m *client.StakingBalance) (*StakingBalance, error) {
-	date, err := time.Parse("2006-01-02", m.Date)
+	date, err := time.Parse(timestampFormat, m.Date)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/coinbase/staking_balance_test.go
+++ b/pkg/coinbase/staking_balance_test.go
@@ -60,7 +60,7 @@ func TestListHistoricalStakingBalances(t *testing.T) {
 					Data: []client.StakingBalance{
 						{
 							ParticipantType: "participantType",
-							Date:            parsedTime.Format("2006-01-02"),
+							Date:            parsedTime.Format(timestampFormat),
 							BondedStake: client.Balance{
 								Amount: "123",
 								Asset: client.Asset{

--- a/pkg/coinbase/staking_reward.go
+++ b/pkg/coinbase/staking_reward.go
@@ -116,7 +116,7 @@ func (s StakingReward) Amount() (*big.Float, error) {
 
 // Date returns the date of the staking reward.
 func (s StakingReward) Date() (time.Time, error) {
-	parsedDate, err := time.Parse(time.DateOnly, s.model.GetDate())
+	parsedDate, err := time.Parse(timestampFormat, s.model.GetDate())
 	if err != nil {
 		return time.Time{}, fmt.Errorf("invalid date found: %s", s.model.GetDate())
 	}

--- a/pkg/coinbase/staking_reward_test.go
+++ b/pkg/coinbase/staking_reward_test.go
@@ -261,13 +261,13 @@ func TestAmount(t *testing.T) {
 func TestDate(t *testing.T) {
 	stakingReward := StakingReward{
 		model: api.StakingReward{
-			Date: "2024-08-10",
+			Date: "2024-08-10T00:00:11Z",
 		},
 	}
 
 	resp, err := stakingReward.Date()
 	assert.NoError(t, err, "error should be nil")
-	assert.Equal(t, "2024-08-10", resp.Format("2006-01-02"))
+	assert.Equal(t, "2024-08-10T00:00:11Z", resp.Format(timestampFormat))
 }
 
 func mockFetchAsset(t *testing.T, assetsAPI *mocks.AssetsAPI, statusCode int) {

--- a/pkg/coinbase/utils.go
+++ b/pkg/coinbase/utils.go
@@ -13,6 +13,8 @@ const (
 	StakingOperationModePartial = "partial"
 	StakingOperationModeDefault = "default"
 	StakingOperationModeNative  = "native"
+
+	timestampFormat = "2006-01-02T15:04:05Z"
 )
 
 func normalizeNetwork(network string) string {


### PR DESCRIPTION
### What changed? Why?
Align with api changes
- StakingRewards's Date field is now a full timestamp
- StakingBalance's Date field is now a full timestamp

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
