### PR TITLE
fix: relay corrrelation id to end user when backend provides one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix a bug where correlation id returned from backend wasn't being relayed to the user
+
 ## [0.0.10] - 2024-09-20
 
 - Add Solana signing functionality

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -58,6 +58,10 @@ func MapToUserFacing(err error, resp *http.Response) error {
 
 		apiError.Message = clientError.Message
 		apiError.Code = clientError.Code
+		if clientError.CorrelationId != nil {
+			apiError.CorrelationId = *clientError.CorrelationId
+		}
+
 		return apiError
 	}
 

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -26,7 +26,7 @@ func (suite *MapErrorsTestSuite) TestMapToUserFacing_NilError() {
 }
 
 func (suite *MapErrorsTestSuite) TestMapToUserFacing_GenericOpenAPIError() {
-	body := []byte(`{"code": "test_code", "message": "test_message"}`)
+	body := []byte(`{"code": "test_code", "message": "test_message", "correlation_id": "test_correlation_id"}`)
 	openAPIError := createGenericOpenAPIError(body)
 	resp := &http.Response{StatusCode: http.StatusBadRequest}
 
@@ -37,6 +37,7 @@ func (suite *MapErrorsTestSuite) TestMapToUserFacing_GenericOpenAPIError() {
 	assert.True(suite.T(), ok)
 	assert.Equal(suite.T(), "test_code", apiErr.Code)
 	assert.Equal(suite.T(), "test_message", apiErr.Message)
+	assert.Equal(suite.T(), "test_correlation_id", apiErr.CorrelationId)
 	assert.Equal(suite.T(), http.StatusBadRequest, apiErr.HttpStatusCode)
 }
 


### PR DESCRIPTION
### What changed? Why?

This PR helps fix a small bug where we were not relaying back backend correlation id to end user as part of the error message

### Note To Reviwers

I have couple of more PRs coming in at which point I can bump the version and do a EOD release.

### Testing

added unit tests and also tested manually

```
>> go run examples/ethereum/stake/main.go /Users/rohit/code/cb/staking/.coinbase_cloud_api_key_production.json 0x87Bf57c3d7B211a100ee4d00dee08435130A62fA 405fb602cbd9618681f37d3079bb494e341da80e197c2b9d38bc7ad46f11d04f
2024/09/23 13:09:30 stakeable balance: Balance { amount: '206.5928997' asset: 'Asset { networkId: 'ethereum-holesky' assetId: 'eth' contractAddress: '' decimals: '18' }' }
2024/09/23 13:09:30 error building staking operation: APIError{HttpStatusCode: 400, Code: bad_staking_request, Message: Requested stake amount 999999999999999999970270236377088 wei (ETH) is greater than available wallet balance 206592899679428624384 wei (ETH), CorrelationId: 8c7d2c3cfd845c19-SJC}
```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
