### PR TITLE
Modify Broadcast Args In Examples

### DIFF
--- a/examples/solana/claim-stake/main.go
+++ b/examples/solana/claim-stake/main.go
@@ -68,9 +68,11 @@ func main() {
 
 	rpcClient := rpc.New(rpcURL)
 
+	maxRetries := uint(5)
 	opts := rpc.TransactionOpts{
 		SkipPreflight:       false,
-		PreflightCommitment: rpc.CommitmentFinalized,
+		MaxRetries:          &maxRetries,
+		PreflightCommitment: rpc.CommitmentProcessed,
 	}
 
 	for _, transaction := range stakingOperation.Transactions() {

--- a/examples/solana/claim-stake/main.go
+++ b/examples/solana/claim-stake/main.go
@@ -70,8 +70,9 @@ func main() {
 
 	maxRetries := uint(5)
 	opts := rpc.TransactionOpts{
-		SkipPreflight:       false,
-		MaxRetries:          &maxRetries,
+		SkipPreflight: false,
+		MaxRetries:    &maxRetries,
+		// NOTE: In production, consider using rpc.CommitmentFinalized instead to ensure the block is included.
 		PreflightCommitment: rpc.CommitmentProcessed,
 	}
 

--- a/examples/solana/stake/main.go
+++ b/examples/solana/stake/main.go
@@ -68,9 +68,11 @@ func main() {
 
 	rpcClient := rpc.New(rpcURL)
 
+	maxRetries := uint(5)
 	opts := rpc.TransactionOpts{
 		SkipPreflight:       false,
-		PreflightCommitment: rpc.CommitmentFinalized,
+		MaxRetries:          &maxRetries,
+		PreflightCommitment: rpc.CommitmentProcessed,
 	}
 
 	for _, transaction := range stakingOperation.Transactions() {

--- a/examples/solana/stake/main.go
+++ b/examples/solana/stake/main.go
@@ -70,8 +70,9 @@ func main() {
 
 	maxRetries := uint(5)
 	opts := rpc.TransactionOpts{
-		SkipPreflight:       false,
-		MaxRetries:          &maxRetries,
+		SkipPreflight: false,
+		MaxRetries:    &maxRetries,
+		// NOTE: In production, consider using rpc.CommitmentFinalized instead to ensure the block is included.
 		PreflightCommitment: rpc.CommitmentProcessed,
 	}
 

--- a/examples/solana/unstake/main.go
+++ b/examples/solana/unstake/main.go
@@ -68,9 +68,11 @@ func main() {
 
 	rpcClient := rpc.New(rpcURL)
 
+	maxRetries := uint(5)
 	opts := rpc.TransactionOpts{
 		SkipPreflight:       false,
-		PreflightCommitment: rpc.CommitmentFinalized,
+		MaxRetries:          &maxRetries,
+		PreflightCommitment: rpc.CommitmentProcessed,
 	}
 
 	for _, transaction := range stakingOperation.Transactions() {

--- a/examples/solana/unstake/main.go
+++ b/examples/solana/unstake/main.go
@@ -70,8 +70,9 @@ func main() {
 
 	maxRetries := uint(5)
 	opts := rpc.TransactionOpts{
-		SkipPreflight:       false,
-		MaxRetries:          &maxRetries,
+		SkipPreflight: false,
+		MaxRetries:    &maxRetries,
+		// NOTE: In production, consider using rpc.CommitmentFinalized instead to ensure the block is included.
 		PreflightCommitment: rpc.CommitmentProcessed,
 	}
 


### PR DESCRIPTION
### What changed? Why?

This PR changes the Solana staking examples to only use "processed" committment level for the RPC client. This increases the likelihood of the examples working. This commitment level should *not* be used in production, however.
