### PR TITLE
Increase Default HTTP Timeout

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gagliardetto/binary v0.8.0 h1:U9ahc45v9HW0d15LoN++vIXSJyqR/pWw8DDlhd7zvxg=
 github.com/gagliardetto/binary v0.8.0/go.mod h1:2tfj51g5o9dnvsc+fL3Jxr22MuWzYXwx9wEoN0XQ7/c=
+github.com/gagliardetto/gofuzz v1.2.2 h1:XL/8qDMzcgvR4+CyRQW9UGdwPRPMHVJfqQ/uMvSUuQw=
+github.com/gagliardetto/gofuzz v1.2.2/go.mod h1:bkH/3hYLZrMLbfYWA0pWzXmi5TTRZnu4pMGZBkqMKvY=
 github.com/gagliardetto/solana-go v1.10.0 h1:lDuHGC+XLxw9j8fCHBZM9tv4trI0PVhev1m9NAMaIdM=
 github.com/gagliardetto/solana-go v1.10.0/go.mod h1:afBEcIRrDLJst3lvAahTr63m6W2Ns6dajZxe2irF7Jg=
 github.com/gagliardetto/treeout v0.1.4 h1:ozeYerrLCmCubo1TcIjFiOWTTGteOOHND1twdFpgwaw=

--- a/pkg/auth/transport.go
+++ b/pkg/auth/transport.go
@@ -36,7 +36,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		"Correlation-Context",
 		fmt.Sprintf(
 			"%s,%s",
-			fmt.Sprintf("%s=%s", "sdk_version", "0.0.11"),
+			fmt.Sprintf("%s=%s", "sdk_version", "0.0.12"),
 			fmt.Sprintf("%s=%s", "sdk_language", "go"),
 		),
 	)

--- a/pkg/coinbase/client.go
+++ b/pkg/coinbase/client.go
@@ -85,7 +85,7 @@ func NewClient(o ...ClientOption) (*Client, error) {
 
 	if c.baseHTTPClient == nil {
 		c.baseHTTPClient = &http.Client{
-			Timeout: time.Second * 5,
+			Timeout: time.Second * 10,
 			Transport: &http.Transport{
 				TLSHandshakeTimeout: 5 * time.Second,
 			},


### PR DESCRIPTION
### What changed? Why?

This PR increases the default timeout of the HTTP client to ensure normal behavior for some endpoints doesn't time out. Some of the Solana endpoints can take a particularly long time.
