### PR TITLE
Better error handling between SDK and API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## [0.0.15] - 2024-12-02
+
+### Added
+
+- Add `WithIntegratorContractAddress` to allow for setting an explicit integrator contract address for Shared ETH staking.
+
+### Fixed
+
+- Better error handling between the SDK and the API.
+
 ## [0.0.14] - 2024-11-26
 
 ### Added
@@ -21,7 +31,7 @@
 - Added constants for supported network names
 - Added `IsFailedState` and `IsCompleteState` methods to `StakingOperation` to check if the operation is in a failed or complete state
 
-### Changes
+### Changed
 
 - Exposed `IsTerminalState` method on `StakingOperation` to check if the operation is in a terminal state.
 

--- a/pkg/auth/transport.go
+++ b/pkg/auth/transport.go
@@ -36,7 +36,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		"Correlation-Context",
 		fmt.Sprintf(
 			"%s,%s",
-			fmt.Sprintf("%s=%s", "sdk_version", "0.0.14"),
+			fmt.Sprintf("%s=%s", "sdk_version", "0.0.15"),
 			fmt.Sprintf("%s=%s", "sdk_language", "go"),
 		),
 	)

--- a/pkg/coinbase/staking_operation.go
+++ b/pkg/coinbase/staking_operation.go
@@ -22,6 +22,11 @@ func WithStakingOperationMode(mode string) StakingOperationOption {
 	return WithStakingOperationOption("mode", mode)
 }
 
+// WithIntegratorContractAddress allows for the setting of the integrator contract address for Shared ETH staking.
+func WithIntegratorContractAddress(integratorContractAddress string) StakingOperationOption {
+	return WithStakingOperationOption("integrator_contract_address", integratorContractAddress)
+}
+
 // WithStakingOperationOption allows for the passing of custom options
 // to the staking operation, like `mode` or `withdrawal_address`.
 func WithStakingOperationOption(optionKey, optionValue string) StakingOperationOption {

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -49,10 +49,10 @@ func MapToUserFacing(err error, resp *http.Response) error {
 	var openAPIError *client.GenericOpenAPIError
 	if errors.As(err, &openAPIError) {
 		var clientError client.Error
-		if err := clientError.UnmarshalJSON(openAPIError.Body()); err != nil {
+		if unmarshalErr := clientError.UnmarshalJSON(openAPIError.Body()); unmarshalErr != nil {
 			return &APIError{
 				Code:    "unknown",
-				Message: err.Error(),
+				Message: err.Error(), // relay back the original error message as is.
 			}
 		}
 


### PR DESCRIPTION
### What changed? Why?

This PR helps:

1. Fix an edge case in error handling preventing real API errors from bubbling up.
2. Add `WithIntegratorContractAddress` to allow for setting an explicit integrator contract address for Shared ETH staking.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
