### PR TITLE
Add extra support for more getters for the Validator class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Coinbase Go SDK Changelog
 
-## Unreleased
+## [0.0.16] - 2024-12-17
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Coinbase Go SDK Changelog
 
-## [0.0.16] - 2024-12-17
+## [0.0.16] - 2024-12-18
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+
+- Add getters for `Validator` object to expose more data to users.
+- Add test cases for `Validator` object.
+
+
+
 ## [0.0.15] - 2024-12-02
 
 ### Added

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,6 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gagliardetto/binary v0.8.0 h1:U9ahc45v9HW0d15LoN++vIXSJyqR/pWw8DDlhd7zvxg=
 github.com/gagliardetto/binary v0.8.0/go.mod h1:2tfj51g5o9dnvsc+fL3Jxr22MuWzYXwx9wEoN0XQ7/c=
-github.com/gagliardetto/gofuzz v1.2.2 h1:XL/8qDMzcgvR4+CyRQW9UGdwPRPMHVJfqQ/uMvSUuQw=
-github.com/gagliardetto/gofuzz v1.2.2/go.mod h1:bkH/3hYLZrMLbfYWA0pWzXmi5TTRZnu4pMGZBkqMKvY=
 github.com/gagliardetto/solana-go v1.10.0 h1:lDuHGC+XLxw9j8fCHBZM9tv4trI0PVhev1m9NAMaIdM=
 github.com/gagliardetto/solana-go v1.10.0/go.mod h1:afBEcIRrDLJst3lvAahTr63m6W2Ns6dajZxe2irF7Jg=
 github.com/gagliardetto/treeout v0.1.4 h1:ozeYerrLCmCubo1TcIjFiOWTTGteOOHND1twdFpgwaw=

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gagliardetto/binary v0.8.0 h1:U9ahc45v9HW0d15LoN++vIXSJyqR/pWw8DDlhd7zvxg=
 github.com/gagliardetto/binary v0.8.0/go.mod h1:2tfj51g5o9dnvsc+fL3Jxr22MuWzYXwx9wEoN0XQ7/c=
+github.com/gagliardetto/gofuzz v1.2.2 h1:XL/8qDMzcgvR4+CyRQW9UGdwPRPMHVJfqQ/uMvSUuQw=
+github.com/gagliardetto/gofuzz v1.2.2/go.mod h1:bkH/3hYLZrMLbfYWA0pWzXmi5TTRZnu4pMGZBkqMKvY=
 github.com/gagliardetto/solana-go v1.10.0 h1:lDuHGC+XLxw9j8fCHBZM9tv4trI0PVhev1m9NAMaIdM=
 github.com/gagliardetto/solana-go v1.10.0/go.mod h1:afBEcIRrDLJst3lvAahTr63m6W2Ns6dajZxe2irF7Jg=
 github.com/gagliardetto/treeout v0.1.4 h1:ozeYerrLCmCubo1TcIjFiOWTTGteOOHND1twdFpgwaw=

--- a/pkg/coinbase/validator.go
+++ b/pkg/coinbase/validator.go
@@ -187,7 +187,6 @@ func (v Validator) ToJSON() (string, error) {
 		return "", err
 	}
 
-	// Print JSON as string
 	return string(jsonData), nil
 }
 

--- a/pkg/coinbase/validator.go
+++ b/pkg/coinbase/validator.go
@@ -2,6 +2,7 @@ package coinbase
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/coinbase/coinbase-sdk-go/gen/client"
@@ -94,12 +95,100 @@ func (v Validator) Status() client.ValidatorStatus {
 	return v.model.Status
 }
 
+func (v Validator) NetworkID() string {
+	return v.model.NetworkId
+}
+
+func (v Validator) AssetID() string {
+	return v.model.AssetId
+}
+
+func (v Validator) Index() string {
+	if !v.hasEthereumMetadata() {
+		return ""
+	}
+	return v.model.Details.EthereumValidatorMetadata.GetIndex()
+}
+
+func (v Validator) PublicKey() string {
+	if !v.hasEthereumMetadata() {
+		return ""
+	}
+	return v.model.Details.EthereumValidatorMetadata.GetPublicKey()
+}
+
+func (v Validator) WithdrawalAddress() string {
+	if !v.hasEthereumMetadata() {
+		return ""
+	}
+	return v.model.Details.EthereumValidatorMetadata.GetWithdrawalAddress()
+}
+
+func (v Validator) Slashed() bool {
+	if !v.hasEthereumMetadata() {
+		return false
+	}
+	return v.model.Details.EthereumValidatorMetadata.GetSlashed()
+}
+
+func (v Validator) ActivationEpoch() string {
+	if !v.hasEthereumMetadata() {
+		return ""
+	}
+	return v.model.Details.EthereumValidatorMetadata.GetActivationEpoch()
+}
+
+func (v Validator) ExitEpoch() string {
+	if !v.hasEthereumMetadata() {
+		return ""
+	}
+	return v.model.Details.EthereumValidatorMetadata.GetExitEpoch()
+}
+
+func (v Validator) WithdrawableEpoch() string {
+	if !v.hasEthereumMetadata() {
+		return ""
+	}
+	return v.model.Details.EthereumValidatorMetadata.GetWithdrawableEpoch()
+}
+
+func (v Validator) Balance() client.Balance {
+	if !v.hasEthereumMetadata() {
+		return client.Balance{}
+	}
+	return v.model.Details.EthereumValidatorMetadata.GetBalance()
+}
+
+func (v Validator) EffectiveBalance() client.Balance {
+	if !v.hasEthereumMetadata() {
+		return client.Balance{}
+	}
+	return v.model.Details.EthereumValidatorMetadata.GetEffectiveBalance()
+}
+
+func (v Validator) hasEthereumMetadata() bool {
+	if v.model.Details == nil || v.model.Details.EthereumValidatorMetadata == nil {
+		return false
+	}
+	return true
+}
+
 func (v Validator) ToString() string {
 	return fmt.Sprintf(
 		"Validator { Id: '%s' Status: '%s' }",
 		v.ID(),
 		v.Status(),
 	)
+}
+
+func (v Validator) ToJSON() (string, error) {
+	jsonData, err := json.Marshal(v.model)
+	if err != nil {
+		return "", err
+	}
+
+	// Print JSON as string
+	return string(jsonData), nil
 }
 
 func (c *Client) ListValidators(

--- a/pkg/coinbase/validators_test.go
+++ b/pkg/coinbase/validators_test.go
@@ -131,6 +131,58 @@ func (s *ValidatorSuite) TestGetValidator_Failure() {
 	s.EqualError(err, "APIError{HttpStatusCode: 500, Code: unknown, Message: some error calling api}")
 }
 
+func (s *ValidatorSuite) TestGetters() {
+	validator := NewValidator(api.Validator{
+		ValidatorId: "validator-1",
+		NetworkId:   EthereumHolesky,
+		AssetId:     Eth,
+		Status:      api.VALIDATORSTATUS_ACTIVE,
+		Details: &api.ValidatorDetails{
+			EthereumValidatorMetadata: &api.EthereumValidatorMetadata{
+				Index:             "0",
+				PublicKey:         "public-key-1",
+				WithdrawalAddress: "withdrawal-address-1",
+				Slashed:           false,
+				ActivationEpoch:   "epoch-1",
+				ExitEpoch:         "exit-epoch-2",
+				WithdrawableEpoch: "withdrawable-epoch-3",
+				Balance: api.Balance{
+					Amount: "100",
+					Asset: api.Asset{
+						NetworkId: EthereumHolesky,
+						AssetId:   Eth,
+					},
+				},
+				EffectiveBalance: api.Balance{
+					Amount: "200",
+					Asset: api.Asset{
+						NetworkId: EthereumHolesky,
+						AssetId:   Eth,
+					},
+				},
+			},
+		},
+	})
+
+	s.Assert().Equal("validator-1", validator.ID())
+	s.Assert().Equal(EthereumHolesky, validator.NetworkID())
+	s.Assert().Equal(Eth, validator.AssetID())
+	s.Assert().Equal(api.VALIDATORSTATUS_ACTIVE, validator.Status())
+	s.Assert().Equal("0", validator.Index())
+	s.Assert().Equal("public-key-1", validator.PublicKey())
+	s.Assert().Equal("withdrawal-address-1", validator.WithdrawalAddress())
+	s.Assert().Equal(false, validator.Slashed())
+	s.Assert().Equal("epoch-1", validator.ActivationEpoch())
+	s.Assert().Equal("exit-epoch-2", validator.ExitEpoch())
+	s.Assert().Equal("withdrawable-epoch-3", validator.WithdrawableEpoch())
+	s.Assert().Equal("100", validator.Balance().Amount)
+	s.Assert().Equal(EthereumHolesky, validator.Balance().Asset.NetworkId)
+	s.Assert().Equal(Eth, validator.Balance().Asset.AssetId)
+	s.Assert().Equal("200", validator.EffectiveBalance().Amount)
+	s.Assert().Equal(EthereumHolesky, validator.EffectiveBalance().Asset.NetworkId)
+	s.Assert().Equal(Eth, validator.EffectiveBalance().Asset.AssetId)
+}
+
 func (s *ValidatorSuite) mockSuccessfulListValidators(ctx context.Context, networkId string, assetId string, mockValidators *api.ValidatorList) {
 	s.T().Helper()
 


### PR DESCRIPTION
### What changed? Why?

Adding support for more getters to expose the data behind the Validator object.

### Example
`validator.toJSON()`
```
{"asset_id":"eth","details":{"activationEpoch":"epoch-1","balance":{"amount":"100","asset":{"asset_id":"eth","network_id":"ethereum-holesky"}},"effective_balance":{"amount":"200","asset":{"asset_id":"eth","network_id":"ethereum-holesky"}},"exitEpoch":"exit-epoch-2","index":"0","public_key":"public-key-1","slashed":false,"withdrawableEpoch":"withdrawable-epoch-3","withdrawal_address":"withdrawal-address-1"},"network_id":"ethereum-holesky","status":"active","validator_id":"validator-1"}
```


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
