### PR TITLE
feat: expose pending claimable balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Coinbase Go SDK Changelog
 
+## [0.0.18] - 2025-02-10
+
+### Added
+
+- Add `GetPendingClaimableBalance` function to help users get the pending claimable balance for a given address.
+
 ## [0.0.17] - 2025-02-06
 
 ### Added

--- a/pkg/auth/transport.go
+++ b/pkg/auth/transport.go
@@ -36,7 +36,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		"Correlation-Context",
 		fmt.Sprintf(
 			"%s,%s",
-			fmt.Sprintf("%s=%s", "sdk_version", "0.0.17"),
+			fmt.Sprintf("%s=%s", "sdk_version", "0.0.18"),
 			fmt.Sprintf("%s=%s", "sdk_language", "go"),
 		),
 	)

--- a/pkg/coinbase/staking_context_balances.go
+++ b/pkg/coinbase/staking_context_balances.go
@@ -9,9 +9,10 @@ import (
 
 // StakingContextBalance represents the active stakeable balances for a given address and asset.
 type StakingContextBalance struct {
-	StakeableBalance   *Balance
-	UnstakeableBalance *Balance
-	ClaimableBalance   *Balance
+	StakeableBalance        *Balance
+	UnstakeableBalance      *Balance
+	PendingClaimableBalance *Balance
+	ClaimableBalance        *Balance
 }
 
 // StakingBalanceOption allows for the passing of custom options to the staking balance
@@ -35,6 +36,15 @@ func (c *Client) GetUnstakeableBalance(ctx context.Context, assetId string, addr
 	}
 
 	return sb.UnstakeableBalance, nil
+}
+
+func (c *Client) GetPendingClaimableBalance(ctx context.Context, assetId string, address *Address, o ...StakingBalanceOption) (*Balance, error) {
+	sb, err := c.fetchStakingBalances(ctx, assetId, address, o...)
+	if err != nil {
+		return nil, err
+	}
+
+	return sb.PendingClaimableBalance, nil
 }
 
 // GetClaimableBalance returns the claimable balance.
@@ -92,14 +102,20 @@ func newStakingBalancesFromModel(context *client.StakingContext) (*StakingContex
 		return nil, err
 	}
 
+	pendingClaimableBalance, err := newBalanceFromModel(&context.Context.PendingClaimableBalance)
+	if err != nil {
+		return nil, err
+	}
+
 	claimableBalance, err := newBalanceFromModel(&context.Context.ClaimableBalance)
 	if err != nil {
 		return nil, err
 	}
 
 	return &StakingContextBalance{
-		StakeableBalance:   stakeableBalance,
-		UnstakeableBalance: unstakeableBalance,
-		ClaimableBalance:   claimableBalance,
+		StakeableBalance:        stakeableBalance,
+		UnstakeableBalance:      unstakeableBalance,
+		PendingClaimableBalance: pendingClaimableBalance,
+		ClaimableBalance:        claimableBalance,
 	}, nil
 }


### PR DESCRIPTION
### What changed? Why?

This PR helps expose the pending_claimable_balance at SDK level that was being returned from the backend starting this PR https://github.com/coinbase/coinbase-sdk-go/pull/48

### Testing

Example show stakeable, unstakeable and pending claimable balances of a wallet.

```
>> go run examples/ethereum/shared-eth-stake/main.go /Users/rohit/code/cb/staking/.coinbase_cloud_api_key_production.json 0x87Bf57c3d7B211a100ee4d00dee08435130A62fA
2025/02/10 15:24:13 stakeable balance: Balance { amount: '3.254773242' asset: 'Asset { networkId: 'ethereum-holesky' assetId: 'eth' contractAddress: '' decimals: '18' }' }
2025/02/10 15:24:13 unstakeableBalance balance: Balance { amount: '0.2119132771' asset: 'Asset { networkId: 'ethereum-holesky' assetId: 'eth' contractAddress: '' decimals: '18' }' }
2025/02/10 15:24:13 pending claimable balance: Balance { amount: '9.8e-17' asset: 'Asset { networkId: 'ethereum-holesky' assetId: 'eth' contractAddress: '' decimals: '18' }' }
```


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
