### PR TITLE
fix: add network constant for Hoodi and update examples accordingly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Coinbase Go SDK Changelog
 
+## [0.0.24] - 2025-04-18
+
+### Added
+
+- Add network constant for `Hoodi`.
+
 ## [0.0.23] - 2025-04-15
 
 ### Added

--- a/examples/ethereum/dedicated-eth-consensus-unstake-pre-signed-exit-messages/main.go
+++ b/examples/ethereum/dedicated-eth-consensus-unstake-pre-signed-exit-messages/main.go
@@ -6,13 +6,7 @@ import (
 	"math/big"
 	"os"
 
-	"github.com/coinbase/coinbase-sdk-go/gen/client"
 	"github.com/coinbase/coinbase-sdk-go/pkg/coinbase"
-)
-
-var (
-	networkID = client.NETWORKIDENTIFIER_ETHEREUM_HOODI
-	assetID   = coinbase.Eth
 )
 
 /*
@@ -31,9 +25,9 @@ func main() {
 		log.Fatalf("error creating coinbase client: %v", err)
 	}
 
-	address := coinbase.NewExternalAddress(string(networkID), os.Args[2])
+	address := coinbase.NewExternalAddress(coinbase.EthereumHoodi, os.Args[2])
 
-	unstakeableBalance, err := client.GetUnstakeableBalance(ctx, assetID, address, coinbase.WithNativeStakingBalanceMode())
+	unstakeableBalance, err := client.GetUnstakeableBalance(ctx, coinbase.Eth, address, coinbase.WithNativeStakingBalanceMode())
 	if err != nil {
 		log.Fatalf("error getting unstakeableBalance balance: %v", err)
 	}
@@ -53,7 +47,7 @@ func main() {
 	unstakeOperation, err := client.BuildUnstakeOperation(
 		ctx,
 		big.NewFloat(64),
-		assetID,
+		coinbase.Eth,
 		address,
 		options...,
 	)

--- a/examples/ethereum/dedicated-eth-execution-unstake/main.go
+++ b/examples/ethereum/dedicated-eth-execution-unstake/main.go
@@ -6,16 +6,10 @@ import (
 	"math/big"
 	"os"
 
-	"github.com/coinbase/coinbase-sdk-go/gen/client"
 	"github.com/coinbase/coinbase-sdk-go/pkg/coinbase"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
-)
-
-var (
-	networkID = client.NETWORKIDENTIFIER_ETHEREUM_HOODI
-	assetID   = coinbase.Eth
 )
 
 /*
@@ -34,9 +28,9 @@ func main() {
 		log.Fatalf("error creating coinbase client: %v", err)
 	}
 
-	withdrawalAddress := coinbase.NewExternalAddress(string(networkID), os.Args[2])
+	withdrawalAddress := coinbase.NewExternalAddress(coinbase.EthereumHoodi, os.Args[2])
 
-	unstakeableBalance, err := client.GetUnstakeableBalance(ctx, assetID, withdrawalAddress, coinbase.WithNativeStakingBalanceMode())
+	unstakeableBalance, err := client.GetUnstakeableBalance(ctx, coinbase.Eth, withdrawalAddress, coinbase.WithNativeStakingBalanceMode())
 	if err != nil {
 		log.Fatalf("error getting unstakeableBalance balance: %v", err)
 	}
@@ -61,7 +55,7 @@ func main() {
 	unstakeOperation, err := client.BuildUnstakeOperation(
 		ctx,
 		big.NewFloat(0), // Amount here doesn't matter.
-		assetID,
+		coinbase.Eth,
 		withdrawalAddress,
 		options...,
 	)

--- a/examples/ethereum/dedicated-eth-stake/main.go
+++ b/examples/ethereum/dedicated-eth-stake/main.go
@@ -6,16 +6,10 @@ import (
 	"math/big"
 	"os"
 
-	"github.com/coinbase/coinbase-sdk-go/gen/client"
 	"github.com/coinbase/coinbase-sdk-go/pkg/coinbase"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
-)
-
-var (
-	networkID = client.NETWORKIDENTIFIER_ETHEREUM_HOODI
-	assetID   = coinbase.Eth
 )
 
 /*
@@ -34,9 +28,9 @@ func main() {
 		log.Fatalf("error creating coinbase client: %v", err)
 	}
 
-	address := coinbase.NewExternalAddress(string(networkID), os.Args[2])
+	address := coinbase.NewExternalAddress(coinbase.EthereumHoodi, os.Args[2])
 
-	stakeableBalance, err := client.GetStakeableBalance(ctx, assetID, address, coinbase.WithNativeStakingBalanceMode())
+	stakeableBalance, err := client.GetStakeableBalance(ctx, coinbase.Eth, address, coinbase.WithNativeStakingBalanceMode())
 	if err != nil {
 		log.Fatalf("error getting stakeable balance: %v", err)
 	}
@@ -52,7 +46,7 @@ func main() {
 	stakeOperation, err := client.BuildStakeOperation(
 		ctx,
 		big.NewFloat(64),
-		assetID,
+		coinbase.Eth,
 		address,
 		options...,
 	)
@@ -101,7 +95,7 @@ func main() {
 		log.Printf("Broadcasted transaction hash: %s", rawTx.Hash().Hex())
 	}
 
-	listMyValidators(ctx, client, string(networkID), assetID, coinbase.ValidatorStatusProvisioned)
+	listMyValidators(ctx, client, coinbase.EthereumHoodi, coinbase.Eth, coinbase.ValidatorStatusProvisioned)
 }
 
 func listMyValidators(ctx context.Context, client *coinbase.Client, networkID string, assetID string, status coinbase.ValidatorStatus) {

--- a/pkg/auth/transport.go
+++ b/pkg/auth/transport.go
@@ -36,7 +36,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		"Correlation-Context",
 		fmt.Sprintf(
 			"%s,%s",
-			fmt.Sprintf("%s=%s", "sdk_version", "0.0.23"),
+			fmt.Sprintf("%s=%s", "sdk_version", "0.0.24"),
 			fmt.Sprintf("%s=%s", "sdk_language", "go"),
 		),
 	)

--- a/pkg/coinbase/utils.go
+++ b/pkg/coinbase/utils.go
@@ -17,6 +17,7 @@ const (
 	StakingOperationModeDefault = "default"
 	StakingOperationModeNative  = "native"
 
+	EthereumHoodi   = string(client.NETWORKIDENTIFIER_ETHEREUM_HOODI)
 	EthereumHolesky = string(client.NETWORKIDENTIFIER_ETHEREUM_HOLESKY)
 	EthereumMainnet = string(client.NETWORKIDENTIFIER_ETHEREUM_MAINNET)
 


### PR DESCRIPTION
### What changed? Why?

This PR helps add missing network constant for Hoodi so that end users can call it via `coinbase.EthereumHoodi`


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
