### PR TITLE
feat: Support validator top ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Coinbase Go SDK Changelog
 
+## [0.0.27] - 2025-05-09
+
+### Added
+
+- Add support for validator top-ups.
+
 ## [0.0.26] - 2025-05-06
 
 ### Added

--- a/examples/ethereum/dedicated-eth-top-up/main.go
+++ b/examples/ethereum/dedicated-eth-top-up/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"log"
+	"math/big"
+	"os"
+
+	"github.com/coinbase/coinbase-sdk-go/pkg/coinbase"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+/*
+ * This example code tops up an existing validator on the Hoodi network with some ETH.
+ * Run the code with 'go run examples/ethereum/dedicated-eth-top-up/main.go <api_key_file_path> <funding_wallet_address> <top-up-validator-pubkey> <private_key> <rpc_url>'
+ */
+
+func main() {
+	ctx := context.Background()
+
+	client, err := coinbase.NewClient(
+		coinbase.WithAPIKeyFromJSON(os.Args[1]),
+	)
+
+	if err != nil {
+		log.Fatalf("error creating coinbase client: %v", err)
+	}
+
+	address := coinbase.NewExternalAddress(coinbase.EthereumHoodi, os.Args[2])
+
+	options := []coinbase.StakingOperationOption{
+		coinbase.WithNativeStakingOperationMode(),
+		coinbase.WithTopUpValidatorPublicKey(os.Args[3]),
+	}
+
+	topUpOperation, err := client.BuildStakeOperation(
+		ctx,
+		big.NewFloat(1), // Top Up 1 ETH
+		coinbase.Eth,
+		address,
+		options...,
+	)
+	if err != nil {
+		log.Fatalf("error building staking operation: %v", err)
+	}
+
+	log.Printf("staking operation ID: %s\n", topUpOperation.ID())
+
+	if err := client.Wait(ctx, topUpOperation, coinbase.WithWaitTimeoutSeconds(600)); err != nil {
+		log.Fatalf("error waiting for staking operation: %v", err)
+	}
+
+	// Load your wallet's private key from which you initiated the above top up operation.
+	key, err := crypto.HexToECDSA(os.Args[4])
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Signing top up operation ...")
+
+	// Sign the transactions within staking operation resource with your private key.
+	if err := topUpOperation.Sign(key); err != nil {
+		log.Fatal(err)
+	}
+
+	// For Hoodi, publicly available RPC URL's can be found here https://chainlist.org/chain/560048
+	ethClient, err := ethclient.Dial(os.Args[5])
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Broadcast each of the signed transactions to the network.
+	for index, transaction := range topUpOperation.Transactions() {
+		log.Printf("Deposit tx %d: %s\n", index+1, transaction.UnsignedPayload())
+
+		rawTx, ok := transaction.Raw().(*types.Transaction)
+		if !ok {
+			log.Fatal("Failed to cast to *types.Transaction")
+		}
+
+		if err := ethClient.SendTransaction(context.Background(), rawTx); err != nil {
+			log.Fatal(err)
+		}
+
+		log.Printf("Broadcasted transaction hash: %s", rawTx.Hash().Hex())
+	}
+}

--- a/pkg/auth/transport.go
+++ b/pkg/auth/transport.go
@@ -36,7 +36,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		"Correlation-Context",
 		fmt.Sprintf(
 			"%s,%s",
-			fmt.Sprintf("%s=%s", "sdk_version", "0.0.26"),
+			fmt.Sprintf("%s=%s", "sdk_version", "0.0.27"),
 			fmt.Sprintf("%s=%s", "sdk_language", "go"),
 		),
 	)

--- a/pkg/coinbase/staking_operation.go
+++ b/pkg/coinbase/staking_operation.go
@@ -95,6 +95,11 @@ func WithTargetValidatorPublicKey(targetValidatorPublicKey string) StakingOperat
 	return WithStakingOperationOption("target_validator_pubkey", targetValidatorPublicKey)
 }
 
+// WithTopUpValidatorPublicKey allows for the setting of the top up validator public key.
+func WithTopUpValidatorPublicKey(validatorPublicKey string) StakingOperationOption {
+	return WithStakingOperationOption("top_up_validator_pubkey", validatorPublicKey)
+}
+
 type ConsensusLayerExitOptionBuilder struct {
 	validatorPubKeys []string
 }


### PR DESCRIPTION
### What changed? Why?

This PR helps support validator top ups. It uses the existing stake flow, and takes an optional `top_up_validator_pubkey` option as input which if provided the input amount is used as top up amount instead of using it for creating a new validator.


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
