### PR TITLE
chore(ci): upgrade golangci-lint-action to v8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Run linter
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           version: v1.55.2
           args: --timeout 3m


### PR DESCRIPTION
Bumps golangci-lint-action to v8 for future-proofing against runner updates. Workflows compile the same. Reference: https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0