### PR TITLE
Remove support for network Holesky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Coinbase Go SDK Changelog
 
+## [0.0.28] - 2025-06-04
+
+### Removed
+
+- Removed support for testnet Holesky.
+
 ## [0.0.27] - 2025-05-09
 
 ### Added

--- a/examples/ethereum/dedicated-eth-list-validators/main.go
+++ b/examples/ethereum/dedicated-eth-list-validators/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/coinbase/coinbase-sdk-go/pkg/coinbase"
+)
+
+/*
+ * This example code stakes ETH on the Hoodi network via Dedicated ETH Staking.
+ * Run the code with 'go run examples/ethereum/dedicated-eth-list-validators/main.go <api_key_file_path>'
+ */
+
+func main() {
+	ctx := context.Background()
+
+	client, err := coinbase.NewClient(
+		coinbase.WithAPIKeyFromJSON(os.Args[1]),
+	)
+
+	if err != nil {
+		log.Fatalf("error creating coinbase client: %v", err)
+	}
+
+	listMyValidators(ctx, client, coinbase.EthereumHoodi, coinbase.Eth, coinbase.ValidatorStatusUnknown)
+}
+
+func listMyValidators(ctx context.Context, client *coinbase.Client, networkID string, assetID string, status coinbase.ValidatorStatus) {
+	var opts []coinbase.ListValidatorsOption
+
+	if status != coinbase.ValidatorStatusUnknown {
+		opts = append(opts, coinbase.WithListValidatorsStatusOption(status))
+	}
+
+	validators, err := client.ListValidators(ctx, networkID, assetID, opts...)
+	if err != nil {
+		log.Fatalf("error listing validators: %v", err)
+	}
+
+	for _, validator := range validators {
+		log.Printf("%s %s, %s, %s", validator.WithdrawalCredentials(), validator.WithdrawalAddress(), validator.PublicKey(), validator.Status())
+	}
+}

--- a/examples/ethereum/dedicated-eth-top-up/main.go
+++ b/examples/ethereum/dedicated-eth-top-up/main.go
@@ -73,7 +73,7 @@ func main() {
 
 	// Broadcast each of the signed transactions to the network.
 	for index, transaction := range topUpOperation.Transactions() {
-		log.Printf("Deposit tx %d: %s\n", index+1, transaction.UnsignedPayload())
+		log.Printf("Top up tx %d: %s\n", index+1, transaction.SignedPayload())
 
 		rawTx, ok := transaction.Raw().(*types.Transaction)
 		if !ok {

--- a/examples/ethereum/list-staking-balances/main.go
+++ b/examples/ethereum/list-staking-balances/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"time"
@@ -29,7 +30,7 @@ func main() {
 
 	address := coinbase.NewExternalAddress(
 		coinbase.EthereumMainnet,
-		os.Args[1],
+		os.Args[2],
 	)
 
 	balances, err := client.ListHistoricalStakingBalances(
@@ -44,6 +45,6 @@ func main() {
 	}
 
 	for _, balance := range balances {
-		println(balance)
+		fmt.Printf("Bonded stake: %s, Unbonded balance: %s\n", balance.BondedStake().Amount().String(), balance.UnbondedBalance().Amount().String())
 	}
 }

--- a/examples/ethereum/shared-eth-stake/main.go
+++ b/examples/ethereum/shared-eth-stake/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 /*
- * This example code stakes ETH on the Holesky network via Shared ETH Staking.
+ * This example code stakes ETH on the Hoodi network via Shared ETH Staking.
  * Run the code with 'go run examples/ethereum/shared-eth-stake/main.go <api_key_file_path> <wallet_address> <wallet_private_key>'
  */
 
@@ -28,7 +28,7 @@ func main() {
 	}
 
 	address := coinbase.NewExternalAddress(
-		coinbase.EthereumHolesky,
+		coinbase.EthereumHoodi,
 		os.Args[2],
 	)
 

--- a/gen/client/model_network_identifier.go
+++ b/gen/client/model_network_identifier.go
@@ -22,8 +22,8 @@ type NetworkIdentifier string
 const (
 	NETWORKIDENTIFIER_BASE_SEPOLIA NetworkIdentifier = "base-sepolia"
 	NETWORKIDENTIFIER_BASE_MAINNET NetworkIdentifier = "base-mainnet"
-	NETWORKIDENTIFIER_ETHEREUM_HOLESKY NetworkIdentifier = "ethereum-holesky"
 	NETWORKIDENTIFIER_ETHEREUM_HOODI NetworkIdentifier = "ethereum-hoodi"
+	NETWORKIDENTIFIER_ETHEREUM_HOODI2 NetworkIdentifier = "ethereum-hoodi"
 	NETWORKIDENTIFIER_ETHEREUM_SEPOLIA NetworkIdentifier = "ethereum-sepolia"
 	NETWORKIDENTIFIER_ETHEREUM_MAINNET NetworkIdentifier = "ethereum-mainnet"
 	NETWORKIDENTIFIER_POLYGON_MAINNET NetworkIdentifier = "polygon-mainnet"
@@ -40,7 +40,7 @@ const (
 var AllowedNetworkIdentifierEnumValues = []NetworkIdentifier{
 	"base-sepolia",
 	"base-mainnet",
-	"ethereum-holesky",
+	"ethereum-hoodi",
 	"ethereum-hoodi",
 	"ethereum-sepolia",
 	"ethereum-mainnet",

--- a/pkg/auth/transport.go
+++ b/pkg/auth/transport.go
@@ -36,7 +36,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		"Correlation-Context",
 		fmt.Sprintf(
 			"%s,%s",
-			fmt.Sprintf("%s=%s", "sdk_version", "0.0.27"),
+			fmt.Sprintf("%s=%s", "sdk_version", "0.0.28"),
 			fmt.Sprintf("%s=%s", "sdk_language", "go"),
 		),
 	)

--- a/pkg/coinbase/staking_operation_test.go
+++ b/pkg/coinbase/staking_operation_test.go
@@ -143,7 +143,7 @@ func (s *StakingOperationSuite) TestStakingOperation_BuildUnstakeOperation_WithE
 
 	decimals := int32(5)
 	asset := &api.Asset{
-		NetworkId: EthereumHolesky,
+		NetworkId: EthereumHoodi,
 		AssetId:   "1",
 		Decimals:  &decimals,
 	}
@@ -164,7 +164,7 @@ func (s *StakingOperationSuite) TestStakingOperation_BuildUnstakeOperation_WithE
 		},
 	}
 
-	address := NewExternalAddress(EthereumHolesky, "1")
+	address := NewExternalAddress(EthereumHoodi, "1")
 
 	builder, err := NewExecutionLayerWithdrawalsOptionBuilder(
 		context.Background(),
@@ -212,7 +212,7 @@ func (s *StakingOperationSuite) TestStakingOperation_BuildUnstakeOperation_WithC
 
 	decimals := int32(5)
 	asset := &api.Asset{
-		NetworkId: EthereumHolesky,
+		NetworkId: EthereumHoodi,
 		AssetId:   "1",
 		Decimals:  &decimals,
 	}
@@ -233,7 +233,7 @@ func (s *StakingOperationSuite) TestStakingOperation_BuildUnstakeOperation_WithC
 		},
 	}
 
-	address := NewExternalAddress(EthereumHolesky, "1")
+	address := NewExternalAddress(EthereumHoodi, "1")
 
 	builder := NewConsensusLayerExitOptionBuilder()
 	builder.AddValidator("0x123")
@@ -276,7 +276,7 @@ func (s *StakingOperationSuite) TestBuildValidatorConsolidationOperation_Success
 
 	decimals := int32(5)
 	asset := &api.Asset{
-		NetworkId: EthereumHolesky,
+		NetworkId: EthereumHoodi,
 		AssetId:   "1",
 		Decimals:  &decimals,
 	}
@@ -287,7 +287,7 @@ func (s *StakingOperationSuite) TestBuildValidatorConsolidationOperation_Success
 		Return(api.ApiBuildStakingOperationRequest{ApiService: mc.stakeAPI})
 
 	op := &api.StakingOperation{Id: "1"}
-	
+
 	mc.stakeAPI.On("BuildStakingOperationExecute", mock.Anything).
 		Return(op, &http.Response{StatusCode: http.StatusOK}, nil)
 
@@ -298,7 +298,7 @@ func (s *StakingOperationSuite) TestBuildValidatorConsolidationOperation_Success
 		},
 	}
 
-	address := NewExternalAddress(EthereumHolesky, "1")
+	address := NewExternalAddress(EthereumHoodi, "1")
 
 	options := []StakingOperationOption{
 		WithSourceValidatorPublicKey("0x123"),
@@ -528,7 +528,7 @@ func (s *StakingOperationSuite) TestSign_SignTransactionFails() {
 
 func (s *StakingOperationSuite) TestReloadStakingOperation_ExistingTransactionsNotOverwritten() {
 	var (
-		networkID               = EthereumHolesky
+		networkID               = EthereumHoodi
 		addressID               = "0x14a34"
 		stakingOperationID      = "staking-operation-id"
 		stakingOperationStatus  = "pending"
@@ -592,7 +592,7 @@ func (s *StakingOperationSuite) TestReloadStakingOperation_ExistingTransactionsN
 
 func (s *StakingOperationSuite) TestReloadStakingOperation_ErrorFormatting() {
 	var (
-		networkID              = EthereumHolesky
+		networkID              = EthereumHoodi
 		addressID              = "0x14a34"
 		stakingOperationID     = "staking-operation-id"
 		stakingOperationStatus = "pending"
@@ -631,7 +631,7 @@ func (s *StakingOperationSuite) TestReloadStakingOperation_ErrorFormatting() {
 
 func (s *StakingOperationSuite) TestFetchStakingOperation_Success() {
 	var (
-		networkID              = EthereumHolesky
+		networkID              = EthereumHoodi
 		addressID              = "0x14a34"
 		stakingOperationID     = "staking-operation-id"
 		stakingOperationStatus = "pending"
@@ -675,7 +675,7 @@ func (s *StakingOperationSuite) TestFetchStakingOperation_Success() {
 
 func (s *StakingOperationSuite) TestFetchStakingOperation_Error() {
 	var (
-		networkID          = EthereumHolesky
+		networkID          = EthereumHoodi
 		addressID          = "0x14a34"
 		stakingOperationID = "staking-operation-id"
 		stakingAPIMock     = mocks.NewStakeAPI(s.T())

--- a/pkg/coinbase/utils.go
+++ b/pkg/coinbase/utils.go
@@ -18,7 +18,6 @@ const (
 	StakingOperationModeNative  = "native"
 
 	EthereumHoodi   = string(client.NETWORKIDENTIFIER_ETHEREUM_HOODI)
-	EthereumHolesky = string(client.NETWORKIDENTIFIER_ETHEREUM_HOLESKY)
 	EthereumMainnet = string(client.NETWORKIDENTIFIER_ETHEREUM_MAINNET)
 
 	SolanaDevnet  = string(client.NETWORKIDENTIFIER_SOLANA_DEVNET)

--- a/pkg/coinbase/validators_test.go
+++ b/pkg/coinbase/validators_test.go
@@ -134,7 +134,7 @@ func (s *ValidatorSuite) TestGetValidator_Failure() {
 func (s *ValidatorSuite) TestGetters() {
 	validator := NewValidator(api.Validator{
 		ValidatorId: "validator-1",
-		NetworkId:   EthereumHolesky,
+		NetworkId:   EthereumHoodi,
 		AssetId:     Eth,
 		Status:      api.VALIDATORSTATUS_ACTIVE,
 		Details: &api.ValidatorDetails{
@@ -149,14 +149,14 @@ func (s *ValidatorSuite) TestGetters() {
 				Balance: api.Balance{
 					Amount: "100",
 					Asset: api.Asset{
-						NetworkId: EthereumHolesky,
+						NetworkId: EthereumHoodi,
 						AssetId:   Eth,
 					},
 				},
 				EffectiveBalance: api.Balance{
 					Amount: "200",
 					Asset: api.Asset{
-						NetworkId: EthereumHolesky,
+						NetworkId: EthereumHoodi,
 						AssetId:   Eth,
 					},
 				},
@@ -165,7 +165,7 @@ func (s *ValidatorSuite) TestGetters() {
 	})
 
 	s.Assert().Equal("validator-1", validator.ID())
-	s.Assert().Equal(EthereumHolesky, validator.NetworkID())
+	s.Assert().Equal(EthereumHoodi, validator.NetworkID())
 	s.Assert().Equal(Eth, validator.AssetID())
 	s.Assert().Equal(api.VALIDATORSTATUS_ACTIVE, validator.Status())
 	s.Assert().Equal("0", validator.Index())
@@ -176,10 +176,10 @@ func (s *ValidatorSuite) TestGetters() {
 	s.Assert().Equal("exit-epoch-2", validator.ExitEpoch())
 	s.Assert().Equal("withdrawable-epoch-3", validator.WithdrawableEpoch())
 	s.Assert().Equal("100", validator.Balance().Amount)
-	s.Assert().Equal(EthereumHolesky, validator.Balance().Asset.NetworkId)
+	s.Assert().Equal(EthereumHoodi, validator.Balance().Asset.NetworkId)
 	s.Assert().Equal(Eth, validator.Balance().Asset.AssetId)
 	s.Assert().Equal("200", validator.EffectiveBalance().Amount)
-	s.Assert().Equal(EthereumHolesky, validator.EffectiveBalance().Asset.NetworkId)
+	s.Assert().Equal(EthereumHoodi, validator.EffectiveBalance().Asset.NetworkId)
 	s.Assert().Equal(Eth, validator.EffectiveBalance().Asset.AssetId)
 }
 


### PR DESCRIPTION
### What changed? Why?

This PR helps deprecate support for testnet Holesky. It has now been replaced by Hoodi for both shared and dedicated eth staking,


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
